### PR TITLE
Adding scratch org workflow

### DIFF
--- a/.github/workflows/spin-scratch-org.yml
+++ b/.github/workflows/spin-scratch-org.yml
@@ -49,23 +49,27 @@ jobs:
         
         - name: Generate Admin Password and Store Info
           run: |
-            
             sf org generate password -o NEW-SCRATCH-ORG
-
             scratch_org_id_18=$(sf org display -o NEW-SCRATCH-ORG --json | jq -r '.result.id')
             scratch_org_id_15=$(echo $scratch_org_id_18 | cut -c 1-15)
+            echo "Scratch Org ID: $scratch_org_id_15"
+
             scratch_org_instance_url=$(sf org display -o NEW-SCRATCH-ORG --json | jq -r '.result.instanceUrl')
             scratch_org_password=$(sf org display -o NEW-SCRATCH-ORG --json | jq -r '.result.password')
-            active_org_record_id=$(sf data query --query "SELECT Id FROM ActiveScratchOrg WHERE ScratchOrg='$scratch_org_id_15'" -o NEW-SCRATCH-ORG --json | jq -r '.result.records[0].Id')
-
-            echo "Scratch Org ID: $scratch_org_id_15"
             echo "Scratch Org instance: $scratch_org_instance_url"
             echo "Scratch Org password: $scratch_org_password"
-            echo "Scratch Org Record Id in DevHub: $active_org_record_id"
 
-            sf data update record --sobject ActiveScratchOrg \
+            scratch_org_record=$(sf data query --query "SELECT Id, SignupUsername FROM ActiveScratchOrg WHERE ScratchOrg='$scratch_org_id_15'" -o DEV_HUB --json)
+            active_org_record_id=$(echo $scratch_org_record | jq -r '.result.records[0].Id')
+            active_org_record_username=$(echo $scratch_org_record | jq -r '.result.records[0].SignupUsername')
+            
+            echo "Scratch Org Record Id in DevHub: $active_org_record_id"
+            echo "Scratch Org Username: $active_org_record_username"
+
+            sf data update record -o DEV_HUB \
+            --sobject ActiveScratchOrg \
             --record-id $active_org_record_id \
-            --values "Instance_URL__c='$scratch_org_instance_url' Password__c='$scratch_org_password'"
+            --values "Instance_URL__c='$scratch_org_instance_url' Username__c='$active_org_record_username' Password__c='$scratch_org_password'"
 
         - name: Get Admin Profile
           run: |

--- a/.github/workflows/spin-scratch-org.yml
+++ b/.github/workflows/spin-scratch-org.yml
@@ -61,15 +61,17 @@ jobs:
 
             scratch_org_record=$(sf data query --query "SELECT Id, SignupUsername FROM ActiveScratchOrg WHERE ScratchOrg='$scratch_org_id_15'" -o DEV_HUB --json)
             active_org_record_id=$(echo $scratch_org_record | jq -r '.result.records[0].Id')
-            active_org_record_username=$(echo $scratch_org_record | jq -r '.result.records[0].SignupUsername')
             
             echo "Scratch Org Record Id in DevHub: $active_org_record_id"
             echo "Scratch Org Username: $active_org_record_username"
 
+            candidate_name=${{ github.event.inputs.firstname }} ${{ github.event.inputs.lastname }}
+            candidate_email="${{ github.event.inputs.email }}"
+
             sf data update record -o DEV_HUB \
             --sobject ActiveScratchOrg \
             --record-id $active_org_record_id \
-            --values "Instance_URL__c='$scratch_org_instance_url' Username__c='$active_org_record_username' Password__c='$scratch_org_password'"
+            --values "Instance_URL__c='$scratch_org_instance_url' Password__c='$scratch_org_password' Candidate_Name__c='$candidate_name' Candidate_Email__c='$candidate_email'"
 
         - name: Get Admin Profile
           run: |

--- a/.github/workflows/spin-scratch-org.yml
+++ b/.github/workflows/spin-scratch-org.yml
@@ -65,7 +65,7 @@ jobs:
             echo "Scratch Org Record Id in DevHub: $active_org_record_id"
             echo "Scratch Org Username: $active_org_record_username"
 
-            candidate_name=${{ github.event.inputs.firstname }} ${{ github.event.inputs.lastname }}
+            candidate_name="${{ github.event.inputs.firstname }} ${{ github.event.inputs.lastname }}"
             candidate_email="${{ github.event.inputs.email }}"
 
             sf data update record -o DEV_HUB \

--- a/.github/workflows/spin-scratch-org.yml
+++ b/.github/workflows/spin-scratch-org.yml
@@ -1,0 +1,87 @@
+name: Issue Scratch Orgs
+on:
+  workflow_dispatch:
+    inputs:
+      firstname:
+        description: 'FirstName'
+        required: true
+        type: string
+        default: ''
+      lastname:
+        description: 'LastName'
+        required: true
+        type: string
+        default: ''
+      email:
+        description: 'Email'
+        required: true
+        type: string
+        default: ''
+
+
+jobs:
+  SPIN-SCRATCH-ORG:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v4
+        - name: Installing Dependencies
+          run: |
+            npm install @salesforce/cli -g
+      
+        - name: Authenticate DevHub Org
+          run: |
+            echo "Authenticate the Salesforce DevHub org"
+            DIRECTORY=`pwd`
+            SERVER_KEY_FILE=$DIRECTORY/server.key
+            echo "${{ secrets.SERVER_KEY }}" > $SERVER_KEY_FILE
+            sf org login jwt --client-id ${{ vars.CLIENT_ID }} \
+            --jwt-key-file server.key \
+            --username ${{ vars.USERNAME }} \
+            --alias DEV_HUB \
+            --instance-url ${{ vars.INSTANCE_URL }}
+
+        - name: Create Scratch Org
+          run: |
+            sf org create scratch --target-dev-hub DEV_HUB \
+            --edition developer \
+            -a NEW-SCRATCH-ORG \
+            --duration-days 30
+        
+        - name: Generate Admin Password and Store Info
+          run: |
+            
+            sf org generate password -o NEW-SCRATCH-ORG
+
+            scratch_org_id_18=$(sf org display -o NEW-SCRATCH-ORG --json | jq -r '.result.id')
+            scratch_org_id_15=$(echo $scratch_org_id_18 | cut -c 1-15)
+            scratch_org_instance_url=$(sf org display -o NEW-SCRATCH-ORG --json | jq -r '.result.instanceUrl')
+            scratch_org_password=$(sf org display -o NEW-SCRATCH-ORG --json | jq -r '.result.password')
+            active_org_record_id=$(sf data query --query "SELECT Id FROM ActiveScratchOrg WHERE ScratchOrg='$scratch_org_id_15'" -o NEW-SCRATCH-ORG --json | jq -r '.result.records[0].Id')
+
+            echo "Scratch Org ID: $scratch_org_id_15"
+            echo "Scratch Org instance: $scratch_org_instance_url"
+            echo "Scratch Org password: $scratch_org_password"
+            echo "Scratch Org Record Id in DevHub: $active_org_record_id"
+
+            sf data update record --sobject ActiveScratchOrg \
+            --record-id $active_org_record_id \
+            --values "Instance_URL__c='$scratch_org_instance_url' Password__c='$scratch_org_password'"
+
+        - name: Get Admin Profile
+          run: |
+            profile_id=$(sf data query --query "SELECT Id FROM Profile WHERE Name='System Administrator'" -o NEW-SCRATCH-ORG --json | jq -r '.result.records[0].Id')
+            echo "Profile ID: $profile_id"
+            echo "profile_id=$profile_id" >> $GITHUB_ENV
+
+        - name: Create Candidate's Users
+          run: |
+            username="${{ github.event.inputs.email }}.challenge"
+            email="${{ github.event.inputs.email }}"
+            alias="${{ github.event.inputs.lastname }}"
+            first_name="${{ github.event.inputs.firstname }}"
+            last_name="${{ github.event.inputs.lastname }}"
+            
+            sf data create record --sobject User \
+            -o NEW-SCRATCH-ORG \
+            --values "Firstname='$first_name' Lastname='$last_name' Username='$username' Email='$email' Alias='$alias' ProfileId='${{ env.profile_id }}' TimeZoneSidKey='America/New_York' LocaleSidKey='en_US' EmailEncodingKey='ISO-8859-1' LanguageLocaleKey='en_US'" \
+            --json


### PR DESCRIPTION
### Description
This workflow do the following
1. Creates Scratch org using DevHub org
2. Generates the password for admin user in the newly created org.
3. Saves the admin credential with other details in the `Active Scratch Org` sObject in DevHub org.
4. Creates the Candidate User in the Scratch org.
5. Saves candidate detail on the scratch org record in DevHub Org.