### PR TITLE
Fixed User Creation in Scratch Org

### DIFF
--- a/.github/workflows/spin-scratch-org.yml
+++ b/.github/workflows/spin-scratch-org.yml
@@ -87,8 +87,7 @@ jobs:
             email="${{ github.event.inputs.email }}"          
             first_name="${{ github.event.inputs.firstname }}"
             last_name="${{ github.event.inputs.lastname }}"
-            alias="${last_name:0:8}"
-#            alias="${{ github.event.inputs.lastname }}"
+            alias=$(echo "$last_name" | cut -c 1-8)
 
             user_id=$(sf data create record --sobject User \
             -o NEW-SCRATCH-ORG \

--- a/.github/workflows/spin-scratch-org.yml
+++ b/.github/workflows/spin-scratch-org.yml
@@ -85,7 +85,7 @@ jobs:
           run: |
             username="${{ github.event.inputs.email }}.challenge"
             email="${{ github.event.inputs.email }}"
-            alias="${{ github.event.inputs.lastname }}"
+            alias="${{ github.event.inputs.lastname }:0:8}"
             first_name="${{ github.event.inputs.firstname }}"
             last_name="${{ github.event.inputs.lastname }}"
             

--- a/.github/workflows/spin-scratch-org.yml
+++ b/.github/workflows/spin-scratch-org.yml
@@ -85,7 +85,7 @@ jobs:
           run: |
             username="${{ github.event.inputs.email }}.challenge"
             email="${{ github.event.inputs.email }}"
-            alias="${{ github.event.inputs.lastname }:0:8}"
+            alias="${{ github.event.inputs.lastname }0:8}"
             first_name="${{ github.event.inputs.firstname }}"
             last_name="${{ github.event.inputs.lastname }}"
             

--- a/.github/workflows/spin-scratch-org.yml
+++ b/.github/workflows/spin-scratch-org.yml
@@ -84,11 +84,12 @@ jobs:
         - name: Create Candidate's Users
           run: |
             username="${{ github.event.inputs.email }}.challenge"
-            email="${{ github.event.inputs.email }}"
-            alias="${{ github.event.inputs.lastname }0:8}"
+            email="${{ github.event.inputs.email }}"          
             first_name="${{ github.event.inputs.firstname }}"
             last_name="${{ github.event.inputs.lastname }}"
-            
+            alias="${last_name:0:8}"
+#            alias="${{ github.event.inputs.lastname }}"
+
             user_id=$(sf data create record --sobject User \
             -o NEW-SCRATCH-ORG \
             --values "Firstname='$first_name' Lastname='$last_name' Username='$username' Email='$email' Alias='$alias' ProfileId='${{ env.profile_id }}' TimeZoneSidKey='America/New_York' LocaleSidKey='en_US' EmailEncodingKey='ISO-8859-1' LanguageLocaleKey='en_US'" \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Reach Financial Logo](./assets/images/reach-financial-logo.svg) 
-# Salesforce-code-challenge
+# salesforce-code-challenge
 
 Reach Financial is a personal lender that offers prospective borrowers the ability to get loans for debt consolidation (e.g., paying off multiple credit cards with a single payment).  
 
@@ -11,7 +11,7 @@ Build a very rudimentary prototype version using a Salesforce scratch org that a
 
 * Clone your forked repo and create a branch to work on.
     
-*   Borrowers use their web browser or mobile device to apply for a loan.
+*   Borrowers use their web browser or mobile device to apply for a loan.  However, making the application process available on a website (e.g. Experience Cloud) is out of scope for this challenge.
     
     *   Borrowers should be able to provide the necessary information to be qualified for a loan:
         
@@ -25,12 +25,10 @@ Build a very rudimentary prototype version using a Salesforce scratch org that a
         
     * We want to capture applicants' information as soon as possible. If they abandon the application process, we want to be able to follow up with them.
             
-    *   Based on those inputs (e.g., total loan consolidation amount and amount of credit cards or other types of loans), a basic offer (price) should be computed and presented to the borrower.
-        
-        *   This offer should include a total loan amount, an interest rate, a term (the length of the loan in months), and a monthly payment.
-            
-            *   If the loan amount requested is less than \$10,000 or greater than \$50,000, deny the application.
-            *   If the number of credit lines is > 50, deny the application.
+    *   Based on those inputs (i.e. Total Loan Amount Requested and Number of Active Credit Cards or Lines of Credit), a basic loan offer should be computed and presented to the borrower.
+
+        *   If the loan amount requested is less than \$10,000 or greater than \$50,000, deny the application.
+        *   If the number of credit lines is > 50, deny the application.           
             
         *   Otherwise, the borrower should be presented with an offer that is pulled directly from this external API:
             * https://raw.githubusercontent.com/ReachFinancial/salesforce-code-challenge/main/assets/data/reach-sample-api-response.json
@@ -40,17 +38,18 @@ Build a very rudimentary prototype version using a Salesforce scratch org that a
         
         *   Parse the response and choose the appropriate offer from it based on the following criteria:
             
-            *   If the number of credit lines is < 10, the 36-month term and 10% interest offer applies.
-            *   If the number of credit lines is >= 10 and <= 50, the 24-month term and 20% interest offer applies. 
+            *   If the number of credit lines is < 10, select the 36-month term and 10% interest offer.
+            *   If the number of credit lines is >= 10 and <= 50, select the 24-month term and 20% interest offer.
                 
-        *   The application's result should be clearly presented to the borrower.
+        *   The selected offer should be clearly presented to the borrower.
+        *   The presented offer should include the total loan amount requested, an interest rate, a term (the length of the loan in months), and a monthly payment.
             
-    *   Once the borrower has agreed to the terms, they are prompted to upload an identity document. The application is then submitted, and the borrower is informed of a 24-hour review turnaround.
+      *   Once the borrower has agreed to the terms, they are prompted to upload an identity document. The application is then submitted, and the borrower is informed of a 24-hour review turnaround.
         
-        *   No special automation for the upload is required. We are only looking to upload and store a document.
+          *   No special automation for the upload is required. We are only looking to upload and store a document.
 
 *   Update your branch with your changes if you haven’t already.
-*   Zip up your branch's changes and email them to your interviewer.
+*   Zip up your development branch and email it to your interviewer.
     
 
 We are looking for a few things specifically, so choose your time wisely:
@@ -59,12 +58,12 @@ We are looking for a few things specifically, so choose your time wisely:
 *   Are you able to integrate Salesforce cleanly with an off-platform web service?
 *   Are you able to write clean LWC front-end code that’s fit for a consumer in a B2C context?
 *   Are you able to approach unit, integration, and end-to-end testing on the platform in step with modern engineering best practices?
-    
 
-To help you focus on the above, we’ve set up a few basic constructs to work from in the this repo that you can fork and work from:
 
-*   The Account object has been set up with Person Accounts
+To help you focus on the above, we’ve set up a few basic constructs to work from in this repo:
+
+*   The `Account` object has been set up with Person Accounts
 *   A new custom `Application__c` object has been created to act as the primary record for the prospective borrower’s application
 *   We’ve created a core Apex class with an invocable action called `getLoanOffer.cls` and its pair test class to give you a place to start.
-*   We’ve created a core Flow to use for the application process called `Reach Application Process`
+*   We’ve created a core Flow to use for the application process called `Application Process - Reach Code Challenge`
 *   We’ve created an LWC called `applicationProcessOfferPresentation` to use for displaying the offer retrieved from the external API


### PR DESCRIPTION
Fixed a bug where the user's alias was being set to a string longer than 8 characters (alias max length), causing the user creation to fail.
Clarified challenge requirements in README.
